### PR TITLE
chore(client): Update styling for links in Thread page and refine con…

### DIFF
--- a/client/src/pages/Thread.tsx
+++ b/client/src/pages/Thread.tsx
@@ -319,7 +319,8 @@ export default function Thread() {
   }
 
   const shouldBlurContent =
-    (!currentUser?.planType || currentUser?.planType === "FREE")  && thread.user.role === "FIGHTER";
+    (!currentUser?.planType || currentUser?.planType === "FREE") &&
+    thread.user.role === "FIGHTER";
 
   // Only render metadata when we have thread data
   const metadata = <ThreadMetadata thread={thread} />;
@@ -335,18 +336,18 @@ export default function Thread() {
           <div className='mb-4 flex items-center text-sm'>
             <Link
               href='/forum'
-              className='text-gray-400 transition hover:text-white'
+              className='flex-shrink-0 text-gray-400 transition hover:text-white'
             >
               Forum
             </Link>
-            <span className='mx-2 text-gray-600'>/</span>
+            <span className='mx-2 flex-shrink-0 text-gray-600'>/</span>
             <Link
               href={`/forum/${thread.categoryId}`}
-              className='text-gray-400 transition hover:text-white'
+              className='flex-shrink-0 text-gray-400 transition hover:text-white'
             >
               {getCategoryName(thread.categoryId)}
             </Link>
-            <span className='mx-2 text-gray-600'>/</span>
+            <span className='mx-2 flex-shrink-0 text-gray-600'>/</span>
             <span className='truncate text-white'>
               {title.length > 30 ? title.substring(0, 30) + "..." : title}
             </span>


### PR DESCRIPTION
…ditional logic for blurring content.
<img width="486" alt="image" src="https://github.com/user-attachments/assets/924babc8-b3ce-4745-b4c7-09542628f294" />


So since we had some flexbox logic here, the spacing was dynamic based on the size of the content -- now it should all be stable independet of the dynaic third breadcrumb which is the thread title... 

This also adds elipsees if we ever need it to the forum cateogry title