### PR TITLE
feat: 🎨 hide media preview dimensions on small screens

### DIFF
--- a/client/src/components/ui/media-preview.tsx
+++ b/client/src/components/ui/media-preview.tsx
@@ -178,7 +178,7 @@ const MediaPreview = ({ media, threadTitle }: MediaPreviewProps) => {
           !hasError &&
           (naturalDimensions.width > 1920 ||
             naturalDimensions.height > 1080) && (
-            <div className='absolute bottom-2 right-2 rounded bg-black bg-opacity-75 px-2 py-1 text-xs text-white'>
+            <div className='absolute bottom-2 right-2 hidden rounded bg-black bg-opacity-75 px-2 py-1 text-xs text-white md:block'>
               {naturalDimensions.width} × {naturalDimensions.height}
             </div>
           )}


### PR DESCRIPTION
This pull request makes a minor UI tweak to the `MediaPreview` component. The change ensures that the image resolution badge is only visible on medium-sized screens and above, improving the interface for mobile users.

* UI update: The image resolution badge in `MediaPreview` is now hidden on small screens and only displayed on `md` (medium) screens and up, using the `hidden` and `md:block` utility classes.